### PR TITLE
Fix to address a performance-related issue wherein the Javascript init bundle is executed each time getMarkup() is called

### DIFF
--- a/ReactJS.php
+++ b/ReactJS.php
@@ -104,9 +104,7 @@ class ReactJS {
       $this->component,
       $this->data);
 
-    ob_start();
-    $this->executeJS($js);      
-    return ob_get_clean();
+    return $this->executeJS($js);
   }
   
   /**
@@ -150,11 +148,13 @@ class ReactJS {
    * Executes Javascript using V8JS, with primitive exception handling
    *
    * @param string $js JS code to be executed
-   * @return mixed
+   * @return string The execution response
    */
   private function executeJS($js) {
     try {
-      return $this->v8->executeString($js);
+      ob_start();
+      $this->v8->executeString($js);
+      return ob_get_clean();
     } catch (V8JsException $e) {
       if ($this->errorHandler) {
         call_user_func($this->errorHandler, $e);

--- a/ReactJS.php
+++ b/ReactJS.php
@@ -17,12 +17,6 @@ class ReactJS {
   
   private
     /**
-     * Concatenated React.js + Application code + boilerplate
-     * @var string
-     */
-    $react,
-    
-    /**
      * Name of the component to render
      * @var string
      */
@@ -64,9 +58,11 @@ class ReactJS {
     // app's components
     $react[] = $appsrc;
     $react[] = ';';
-    $this->react = implode(";\n", $react);
-    
+
+    $concatenated = implode(";\n", $react);
+
     $this->v8 = new V8Js();
+    $this->executeJS($concatenated);
   }
   
   /**
@@ -103,28 +99,14 @@ class ReactJS {
    * @return string HTML string
    */
   function getMarkup() {
-    try {
-      $js = $this->react;
-      $js.= sprintf(
-        "print(React.renderToString(React.createElement(%s, %s)))",
-        $this->component,
-        $this->data);
+    $js = sprintf(
+      "print(React.renderToString(React.createElement(%s, %s)))",
+      $this->component,
+      $this->data);
 
-      ob_start();
-      $this->v8->executeString($js);      
-      return ob_get_clean();
-
-    } catch (V8JsException $e) {
-      if ($this->errorHandler) {
-        call_user_func($this->errorHandler, $e);
-      } else {
-        // default error handler blows up bad
-        echo "<pre>";
-        echo $e->getMessage();
-        echo "</pre>";
-        die(); 
-      }
-    }
+    ob_start();
+    $this->executeJS($js);      
+    return ob_get_clean();
   }
   
   /**
@@ -163,5 +145,28 @@ class ReactJS {
         $where
       );
   }
+
+  /**
+   * Executes Javascript using V8JS, with primitive exception handling
+   *
+   * @param string $js JS code to be executed
+   * @return mixed
+   */
+  private function executeJS($js) {
+    try {
+      return $this->v8->executeString($js);
+    } catch (V8JsException $e) {
+      if ($this->errorHandler) {
+        call_user_func($this->errorHandler, $e);
+      } else {
+        // default error handler blows up bad
+        echo "<pre>";
+        echo $e->getMessage();
+        echo "</pre>";
+        die(); 
+      }
+    }
+  }
+
 }
 


### PR DESCRIPTION
The fix addresses an issue where the concatenated Javascript initialisation code is executed **each time** `ReactJS::getMarkup()` is called. I cannot see a good reason why this should be the case, and my thinking is that the concatenated code bundle should be executed once only - when ReactJS is instantiated.

This way, `ReactJS::getMarkup()` is only responsible for executing the JS `React.renderToString()` method, rather than executing the whole initialisation bundle first, and then calling `.renderToString()` - which seems to be incredibly costly and slow!

This change dramatically speeds up things for me on pages with multiple separate calls to render React components.
