### PR TITLE
Add JSON_NUMERIC_CHECK to convert strings to numerics

### DIFF
--- a/ReactJS.php
+++ b/ReactJS.php
@@ -77,7 +77,7 @@ class ReactJS {
    */
   function setComponent($component, $data = null) {
     $this->component = $component;
-    $this->data = json_encode($data);
+    $this->data = json_encode($data, JSON_NUMERIC_CHECK);
     return $this;
   }
 


### PR DESCRIPTION
Many PHP database driver implementations return all query results as strings and do not do any type conversion. This is usually insignificant because PHP will perform implicit type conversions when necessary.

But for React/JSON we need these types to be explicit. The JSON_NUMERIC_CHECK flag for `json_encode` will detect strings that are like numbers and convert them.