### PR TITLE
`window` should not be defined during SSR

### DIFF
--- a/ReactJS.php
+++ b/ReactJS.php
@@ -52,7 +52,7 @@ class ReactJS {
     $react = array();
     // stubs, react
     $react[] = "var console = {warn: function(){}, error: print};";
-    $react[] = "var global = global || this, self = self || this, window = window || this;";
+    $react[] = "var global = global || this, self = self || this";
     $react[] = $libsrc;
     $react[] = "var React = global.React, ReactDOM = global.ReactDOM, ReactDOMServer = global.ReactDOMServer;";
     // app's components


### PR DESCRIPTION
Some react libraries render their components differently if the window object is defined. Currently if the window object is unefined, ***this*** is assigned to the window, which is not the actual window object. This causes errors like these : 
```js
webpack-internal:///643:57: TypeError: Cannot read property 'userAgent' of undefined
```